### PR TITLE
fix(types): `metaInfo` should always be a member function

### DIFF
--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -13,6 +13,6 @@ declare module "vue/types/options" {
 
 declare module "vue/types/vue" {
   interface Vue {
-    metaInfo?: MetaInfo | (() => MetaInfo)
+    metaInfo(): MetaInfo
   }
 }


### PR DESCRIPTION
In `vue-class-component`, if the defined function is not a member function, it is treated as a data property. Even if you register a custom hook via `Component.registerHooks`, it will not work.